### PR TITLE
Replace `Element` with `OWND Messenger`

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1998,11 +1998,13 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             subtitle = `${this.subTitleStatus} ${subtitle}`;
         }
 
-        const title = `${SdkConfig.get().brand} ${subtitle}`;
-
-        if (document.title !== title) {
-            document.title = title;
-        }
+        // workaround
+        // 適切な方法でbrandを取得する
+        // const title = `${SdkConfig.get().brand} ${subtitle}`;
+        document.title = "OWND Messenger"
+        // if (document.title !== title) {
+        //     document.title = title;
+        // }
     }
 
     private onUpdateStatusIndicator = (notificationState: SummarizedNotificationState, state: SyncState): void => {

--- a/src/components/views/elements/ServerPicker.tsx
+++ b/src/components/views/elements/ServerPicker.tsx
@@ -41,7 +41,11 @@ const showPickerDialog = (
 };
 
 const onHelpClick = (): void => {
-    const brand = SdkConfig.get().brand;
+    // workaround
+    // 適切な方法でアプリ名を取得する
+    // const brand = SdkConfig.get().brand;
+    const brand = "OWND Messenger"
+
     Modal.createDialog(
         InfoDialog,
         {


### PR DESCRIPTION
`SdkConfig`からの値の取得がうまくいかないため、暫定的な方法でbrand名を設定します。

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->