### PR TITLE
Workaround: The combination of SIOPv2 and UIA is not properly impleme…

### DIFF
--- a/src/components/views/settings/tabs/user/DeactivationConfirm.tsx
+++ b/src/components/views/settings/tabs/user/DeactivationConfirm.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {_t} from "../../../../../languageHandler";
+
+interface IProps {
+    onConfirm: () => void;
+    onClose: () => void;
+}
+
+class ConfirmationDialog extends  React.Component<IProps, {}>{
+
+    handleYesClick = () => {
+        this.props.onConfirm();
+    }
+
+    handleNoClick = () => {
+        this.props.onClose();
+    }
+
+    render() {
+        return (
+            <div>
+                <div className="mx_Dialog_content">
+                    <p>{_t("settings|general|deactivate_confirm_content")}</p>
+                    <ul>
+                        <li>{_t("settings|general|deactivate_confirm_content_1")}</li>
+                        <li>{_t("settings|general|deactivate_confirm_content_2")}</li>
+                        <li>{_t("settings|general|deactivate_confirm_content_3")}</li>
+                        <li>{_t("settings|general|deactivate_confirm_content_4")}</li>
+                        <li>{_t("settings|general|deactivate_confirm_content_5")}</li>
+                    </ul>
+                </div>
+                <button onClick={this.handleYesClick}>{_t("action|continue")}</button>
+                <button onClick={this.handleNoClick}>{_t("action|cancel")}</button>
+            </div>
+        );
+    }
+}
+
+export default ConfirmationDialog;


### PR DESCRIPTION
- MatrixのUIA(User Interactive Authentication)とSIOPv2の組み合わせを適切に実装できていない状況。
- 一時的にUIAが不要となるようにサーバーサイドを修正している。
  - https://github.com/datasign-inc/synapse/pull/37
- それにより、ボタン押下で直ちにアカウントの無効化が行われるようになってしまう。
- これを防ぐために独自のダイアログを追加する。

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->